### PR TITLE
Avoid config override by egg-view options

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -24,7 +24,7 @@ module.exports = class EjsView {
   }
 
   async render(filename, locals, viewOptions) {
-    const config = Object.assign({}, this.config, viewOptions, { filename });
+    const config = Object.assign({}, viewOptions, this.config, { filename });
     const html = await this[RENDER](filename, locals, config);
     if (!config.layout) {
       return html;
@@ -37,7 +37,7 @@ module.exports = class EjsView {
 
   renderString(tpl, locals, viewOptions) {
     // should disable cache when no filename
-    const config = Object.assign({}, this.config, viewOptions, { cache: null });
+    const config = Object.assign({}, viewOptions, this.config, { cache: null });
     try {
       return Promise.resolve(ejs.render(tpl, locals, config));
     } catch (err) {


### PR DESCRIPTION
According to the readme, I can set config like below, 

```js
// {app_root}/config/config.default.js
exports.view = {
  mapping: {
    '.ejs': 'ejs',
  },
};

// ejs config
exports.ejs = {};
```

but it doesn't work. Because the config is override by egg-view default options.